### PR TITLE
Log exceptions when possible

### DIFF
--- a/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalCalendarSubscriptionService.java
+++ b/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalCalendarSubscriptionService.java
@@ -696,18 +696,17 @@ public class BaseExternalCalendarSubscriptionService implements
 		}
 		catch (PermissionException e)
 		{
-			// This will never be called (for now)
-			e.printStackTrace();
+			m_log.error("Permission exception", e);
 		}
 		catch (MalformedURLException e)
 		{
 			m_log.error("Mal-formed URL in calendar subscription '" + calendarName
-					+ "': " + url);
+					+ "': " + url, e);
 		}
 		catch (IOException e)
 		{
 			m_log.error("Unable to read calendar subscription '" + calendarName
-					+ "' from URL (I/O Error): " + url);
+					+ "' from URL (I/O Error): " + url, e);
 		}
 		catch (Exception e)
 		{
@@ -721,7 +720,7 @@ public class BaseExternalCalendarSubscriptionService implements
 				try {
 					stream.close();
 				} catch (IOException e) {
-					// Ignore
+					m_log.error("Error while closing stream", e);
 				}
 			}
 		}


### PR DESCRIPTION
Exceptions should be logged if possible to provide more details on what happened.

Even if some code isn't supposed to be called, logging the exception is useful.
