### PR TITLE
WL-3121 Don't blow up when the session is reset.

### DIFF
--- a/calendar-summary-tool/tool/src/java/org/sakaiproject/util/ResourceLoaderWrapper.java
+++ b/calendar-summary-tool/tool/src/java/org/sakaiproject/util/ResourceLoaderWrapper.java
@@ -1,0 +1,37 @@
+package org.sakaiproject.util;
+
+/**
+ * <p>
+ * MyFaces has a issue/bug whereby if a managed bean implements Map then it calls {@link #put(Object, Object)} rather
+ * than an explicit setter. This means that setting the baseName for the resource bundle doesn't work on
+ * the plain ResourceLoader as ResourceLoader doesn't support {@link #put(Object, Object)}.
+ * </p>
+ * <p>
+ * We also implement {@link #get(Object)} because with MyFaces is initialising managed properties it calls the setting
+ * first and without this we get warning about using a null bundle.
+ * </p>
+ *
+ * @author Matthew Buckett
+ */
+public class ResourceLoaderWrapper  extends ResourceLoader {
+
+	@Override
+	public Object get(Object key) {
+		if ("baseName".equals(key)) {
+			return baseName;
+		} else {
+			return super.get(key);
+		}
+	}
+
+	@Override
+	public Object put(Object key, Object value) {
+		if ("baseName".equals(key) && value instanceof String) {
+			setBaseName((String)value);
+			return null;
+		} else {
+			throw new IllegalArgumentException("We don't support put() with :"+ key);
+		}
+	}
+
+}

--- a/calendar-summary-tool/tool/src/webapp/WEB-INF/faces-config.xml
+++ b/calendar-summary-tool/tool/src/webapp/WEB-INF/faces-config.xml
@@ -18,7 +18,7 @@
 	<managed-bean>
 		<description>Dynamic Resource Bundle Loader</description>
 		<managed-bean-name>msgs</managed-bean-name>
-		<managed-bean-class>org.sakaiproject.util.ResourceLoader</managed-bean-class>
+		<managed-bean-class>org.sakaiproject.util.ResourceLoaderWrapper</managed-bean-class>
 		<managed-bean-scope>session</managed-bean-scope>
 		<managed-property>
 			<description>Bundle baseName</description>

--- a/calendar-summary-tool/tool/src/webapp/summary-calendar/calendar.jsp
+++ b/calendar-summary-tool/tool/src/webapp/summary-calendar/calendar.jsp
@@ -10,12 +10,6 @@
 	response.addHeader("Pragma", "no-cache");
 %>
 
-<% try{ %>
-<jsp:useBean id="msgs" class="org.sakaiproject.util.ResourceLoader" scope="session">
-   <jsp:setProperty name="msgs" property="baseName" value="calendar"/>
-</jsp:useBean>
-<% }catch(Exception e) {return;} %>
-
 <f:view>
 <sakai:view title="#{msgs.tool_title}" id="sakaiview" toolCssHref="/sakai-calendar-summary-tool/summary-calendar/css/cal.css">
 	

--- a/calendar-summary-tool/tool/src/webapp/summary-calendar/prefs.jsp
+++ b/calendar-summary-tool/tool/src/webapp/summary-calendar/prefs.jsp
@@ -9,12 +9,6 @@
 	response.addHeader("Pragma", "no-cache");
 %>
 
-<% try{ %>
-<jsp:useBean id="msgs" class="org.sakaiproject.util.ResourceLoader" scope="session">
-   <jsp:setProperty name="msgs" property="baseName" value="calendar"/>
-</jsp:useBean>
-<% }catch(Exception e) {return;} %>
-
 <f:view>
 <sakai:view title="#{msgs.tool_title}">
 	<sakai:script contextBase="/jsf-resource/" path="/inputColor/inputColor.js"/>

--- a/calendar-summary-tool/tool/src/webapp/summary-calendar/subscribe.jsp
+++ b/calendar-summary-tool/tool/src/webapp/summary-calendar/subscribe.jsp
@@ -9,12 +9,6 @@
 	response.addHeader("Pragma", "no-cache");
 %>
 
-<% try{ %>
-<jsp:useBean id="msgs" class="org.sakaiproject.util.ResourceLoader" scope="session">
-   <jsp:setProperty name="msgs" property="baseName" value="calendar"/>
-</jsp:useBean>
-<% }catch(Exception e) {return;} %>
-
 <f:view>
 <sakai:view title="#{msgs.tool_title}">
 	


### PR DESCRIPTION
When the calendar tool loses it's session part way through it's request it can cause the managed bean to be created. The managed bean doesn't work and so the request blows up.

The workaround that the tool used was to initialise the resource loader using a JSP script-let at the top of the file. I've switched to creating a wrapper that allows the resource loader to be used as a managed bean. This is because managed beans are the standard way of working in the JSF world and it save the JSPs from having script-lets at the top of each file.
