### PR TITLE
WL-4274 Modified calendar entity to support calendar component in Lesson

### DIFF
--- a/calendar-api/api/src/java/org/sakaiproject/calendar/api/CalendarService.java
+++ b/calendar-api/api/src/java/org/sakaiproject/calendar/api/CalendarService.java
@@ -395,7 +395,13 @@ public interface CalendarService
 	 * @return The the internal reference which can be used to access the calendar-in-pdf format from within the system.
 	 */
 	public String calendarOpaqueUrlReference(Reference ref);
-	
+
+	/**
+	 * Returns all calendar references for a given siteId
+	 * @param siteId Id of the site
+	 * @return List object is returned with all calendar references
+	 */
+	public List<String> getCalendarReferences(String siteId);
 }	// CalendarService
 
 

--- a/calendar-bundles/resources/calendar.properties
+++ b/calendar-bundles/resources/calendar.properties
@@ -488,10 +488,15 @@ ical_opaqueurl_delete=Delete
 
 # EntityProvider properties
 calendar=Represents calendar events.
-calendar.action.site=Retrieve the calendar events for a site. The request url pattern: /direct/calendar/site/{siteId}.{format}
+calendar.action.site=Retrieve the calendar events for a site. The request url pattern: /direct/calendar/site/{siteId}.{format} \
+Optional query params: \
+firstDate, ISO-8601 yyyy-MM-dd format. Used for filtering. \
+lastDate, ISO-8601 yyyy-MM-dd format. Used for filtering.
 calendar.action.event=Retrieve a calendar event details specified by the site id and event id. The request url pattern: /direct/calendar/event/{siteId}/{eventId}.{format}
-calendar.action.my=Retrieve all my calendar events for all of my sites. The request url pattern: /direct/calendar/my.{format}
-
+calendar.action.my=Retrieve all my calendar events for all of my sites. The request url pattern: /direct/calendar/my.{format} \
+Optional query params: \
+firstDate, ISO-8601 yyyy-MM-dd format. Used for filtering. \
+lastDate, ISO-8601 yyyy-MM-dd format. Used for filtering.
 # Monday/Wednesday/Friday
 set.MWF.fm= {0}/{1}/{2}
 # Tuesday/Thursday

--- a/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -7413,8 +7413,13 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 			}
 		}
 	}
-	
-	protected List<String> getCalendarReferences(String siteId) {
+
+	/**
+	 * JavaDoc can be found org.sakaiproject.calendar.api.CalendarService.
+	 * @param siteId
+	 * @return
+	 */
+	public List<String> getCalendarReferences(String siteId) {
 		// get merged calendars channel refs
 		String initMergeList = null;
 		try {

--- a/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/CalendarBean.java
+++ b/calendar-summary-tool/tool/src/java/org/sakaiproject/tool/summarycalendar/ui/CalendarBean.java
@@ -203,27 +203,7 @@ public class CalendarBean {
 	
 	private List getCalendarReferences() {
 		// get merged calendars channel refs
-		String initMergeList = null;
-		try{
-			ToolConfiguration tc = M_ss.getSite(getSiteId()).getToolForCommonId(SCHEDULE_TOOL_ID);
-			if(tc != null) {
-				initMergeList = tc.getPlacementConfig().getProperty(MERGED_CALENDARS_PROP);
-			}
-		}catch(IdUnusedException e){
-			initMergeList = null;
-		}
-		
-		// load all calendar channels (either primary or merged calendars)
-		String primaryCalendarReference = M_ca.calendarReference(getSiteId(), SiteService.MAIN_CONTAINER);
- 		MergedList mergedCalendarList = loadChannels(primaryCalendarReference, initMergeList, null);
- 		
-		// add external calendar subscriptions
-        List referenceList = mergedCalendarList.getReferenceList();
-        Set subscriptionRefList = M_ecs.getCalendarSubscriptionChannelsForChannels(
-        		primaryCalendarReference,
-        		referenceList);
-        referenceList.addAll(subscriptionRefList);
-				
+		List referenceList = M_ca.getCalendarReferences(getSiteId());
 		return referenceList;
 	}
 	

--- a/calendar-tool/tool/src/java/org/sakaiproject/calendar/entityproviders/CalendarEventEntityProvider.java
+++ b/calendar-tool/tool/src/java/org/sakaiproject/calendar/entityproviders/CalendarEventEntityProvider.java
@@ -1,16 +1,17 @@
 package org.sakaiproject.calendar.entityproviders;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import lombok.Setter;
+import java.io.IOException;
+import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.calendar.api.Calendar;
 import org.sakaiproject.calendar.api.CalendarEvent;
+import org.sakaiproject.calendar.api.CalendarEventVector;
 import org.sakaiproject.calendar.api.CalendarService;
-import org.sakaiproject.entitybroker.DeveloperHelperService;
+import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entitybroker.EntityView;
 import org.sakaiproject.entitybroker.entityprovider.EntityProvider;
 import org.sakaiproject.entitybroker.entityprovider.annotations.EntityCustomAction;
@@ -26,10 +27,16 @@ import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.time.api.Time;
+import org.sakaiproject.time.api.TimeRange;
+import org.sakaiproject.time.api.TimeService;
+
+import lombok.Setter;
+import org.sakaiproject.util.CalendarUtil;
 
 /**
  * The sakai entity used to access calendar events.
- * 
+ *
  * @author Denny
  */
 public class CalendarEventEntityProvider extends AbstractEntityProvider
@@ -37,6 +44,18 @@ public class CalendarEventEntityProvider extends AbstractEntityProvider
 		ActionsExecutable, Outputable, Sampleable {
 
 	String ENTITY_PREFIX = "calendar";
+	Properties config = new Properties();
+	Map<String, String> eventImageMap = Collections.emptyMap();
+	private static Log log = LogFactory.getLog(CalendarEventEntityProvider.class);
+
+	public void init(){
+		try {
+			config.load(getClass().getResourceAsStream("/org/sakaiproject/calendar/tool/calendar.config"));
+		} catch (IOException e) {
+			//config file is missing
+			log.warn("Calendar.config file is missing for CalendarEventEntityProvider.class : " + e.getMessage());
+		}
+	}
 
 	/**
 	 * Calendar service.
@@ -51,10 +70,12 @@ public class CalendarEventEntityProvider extends AbstractEntityProvider
 	private SiteService siteService;
 
 	/**
-	 * Reference to the developer helper service.
+	 * Time service.
 	 */
 	@Setter
-	private DeveloperHelperService developerHelperService;
+	private transient TimeService timeService;
+	@Setter
+	private EntityManager entityManager;
 
 	/**
 	 * @return prefix
@@ -83,9 +104,8 @@ public class CalendarEventEntityProvider extends AbstractEntityProvider
 
 	/**
 	 * Checks if an entity exists.
-	 * 
-	 * @param id
-	 *            id
+	 *
+	 * @param id id
 	 * @return if entity exists
 	 */
 	public boolean entityExists(final String id) {
@@ -94,95 +114,67 @@ public class CalendarEventEntityProvider extends AbstractEntityProvider
 
 	/**
 	 * site/siteId
+	 *
+	 * Optional firstDate and lastDate query params in ISO-8601 date format, YYYY-MM-DD
 	 */
 	@EntityCustomAction(action = "site", viewKey = EntityView.VIEW_LIST)
-	public List<CalendarEventSummary> getCalendarEventsForSite(EntityView view) {
-		List<CalendarEventSummary> r = new ArrayList<CalendarEventSummary>();
+	public List<CalendarEventSummary> getCalendarEventsForSite(final EntityView view, final Map<String, Object> params) {
+
+		final List<CalendarEventSummary> rv = new ArrayList<CalendarEventSummary>();
 
 		// get siteId
-		String siteId = view.getPathSegment(2);
+		final String siteId = view.getPathSegment(2);
 
 		// check siteId supplied
 		if (StringUtils.isBlank(siteId)) {
 			throw new IllegalArgumentException(
-					"siteId must be set in order to get the news feeds for a site, via the URL /news/site/siteId");
+					"siteId must be set in order to get the calendar feeds for a site, via the URL /calendar/site/siteId");
 		}
 
-		// user being logged in and having access to the site is handled in the
-		// API
-		Calendar cal;
-		try {
-			cal = calendarService.getCalendar(String.format(
-					"/calendar/calendar/%s/main", siteId));
+		eventImageMap = new CalendarUtil().getEventImageMap(config);
 
-			for (Object o : cal.getEvents(null, null)) {
-				CalendarEvent event = (CalendarEvent) o;
+		// optional timerange
+		final TimeRange range = buildTimeRangeFromRequest(params);
 
-				r.add(new CalendarEventSummary(event));
-			}
-
-			return r;
-		} catch (IdUnusedException e) {
-			throw new EntityNotFoundException("Invalid siteId: " + siteId,
-					siteId);
-		} catch (PermissionException e) {
-			throw new EntityNotFoundException("No access to site: " + siteId,
-					siteId);
+		//check if request is for merged calendars, used by lessons widget
+		if(params.containsKey("merged") && (params.get("merged")).equals("true")){
+			//get all events from the merged calendars
+			rv.addAll(getMergedCalendarEventsForSite(siteId, range));
 		}
+		else{
+			// user being logged in and having access to the site is handled in the API
+			rv.addAll(getEventsForSite(siteId, range));
+		}
+		return rv;
 	}
 
 	/**
 	 * my
+	 *
+	 * Optional firstDate and lastDate query params in ISO-8601 date format, YYYY-MM-DD
 	 */
 	@EntityCustomAction(action = "my", viewKey = EntityView.VIEW_LIST)
 	public List<CalendarEventSummary> getMyCalendarEventsForAllSite(
-			EntityView view, Map<String, Object> params) {
-		List<CalendarEventSummary> rv = new ArrayList<CalendarEventSummary>();
+			final EntityView view, final Map<String, Object> params) {
+		final List<CalendarEventSummary> rv = new ArrayList<CalendarEventSummary>();
+
+		// optional timerange
+		final TimeRange range = buildTimeRangeFromRequest(params);
 
 		// add events form my workspace
-		Calendar cal;
-		try {
-			cal = calendarService.getCalendar(String.format(
-					"/calendar/calendar/~%s/main",
-					developerHelperService.getCurrentUserId()));
-
-			for (Object o : cal.getEvents(null, null)) {
-				CalendarEvent event = (CalendarEvent) o;
-
-				rv.add(new CalendarEventSummary(event));
-			}
-		} catch (IdUnusedException e) {
-			// should not happened
-		} catch (PermissionException e) {
-			// should not happened
-		}
+		final String siteId = "~" + this.developerHelperService.getCurrentUserId();
+		rv.addAll(getEventsForSite(siteId, range));
 
 		// get list of all sites
-		List<Site> sites = siteService.getSites(
+		final List<Site> sites = this.siteService.getSites(
 				SiteService.SelectionType.ACCESS, null, null, null,
 				SiteService.SortType.TITLE_ASC, null);
 		// no need to check user can access this site, as the get sites only
 		// returned accessible sites
 
 		// get all assignments from each site
-		for (Site site : sites) {
-			String siteId = site.getId();
-
-			try {
-				cal = calendarService.getCalendar(String.format(
-						"/calendar/calendar/%s/main", siteId));
-
-				for (Object o : cal.getEvents(null, null)) {
-					CalendarEvent event = (CalendarEvent) o;
-
-					rv.add(new CalendarEventSummary(event));
-				}
-			} catch (IdUnusedException e) {
-				// should not happened
-			} catch (PermissionException e) {
-				// should not happened
-			}
-
+		for (final Site site : sites) {
+			rv.addAll(getEventsForSite(site.getId(), range));
 		}
 		return rv;
 	}
@@ -191,32 +183,141 @@ public class CalendarEventEntityProvider extends AbstractEntityProvider
 	 * event/siteId/eventId
 	 */
 	@EntityCustomAction(action = "event", viewKey = EntityView.VIEW_LIST)
-	public CalendarEventDetails getCalendarEventDetails(EntityView view) {
+	public CalendarEventDetails getCalendarEventDetails(final EntityView view) {
 		// get siteId
-		String siteId = view.getPathSegment(2);
-		String eventId = view.getPathSegment(3);
+		final String siteId = view.getPathSegment(2);
+		final String eventId = view.getPathSegment(3);
 
 		// check siteId supplied
 		if (StringUtils.isBlank(siteId)) {
 			throw new IllegalArgumentException(
-					"siteId must be set in order to get the news feeds for a site, via the URL /news/site/siteId");
+					"siteId must be set in order to get the calendar feeds for a site, via the URL /calendar/site/siteId");
 		}
 
 		// user being logged in and having access to the site is handled in the
 		// API
 		Calendar cal;
 		try {
-			cal = calendarService.getCalendar(String.format(
+			cal = this.calendarService.getCalendar(String.format(
 					"/calendar/calendar/%s/main", siteId));
 
-			return new CalendarEventDetails(cal.getEvent(eventId));
-		} catch (IdUnusedException e) {
+			final CalendarEvent event = cal.getEvent(eventId);
+			final CalendarEventDetails rval = new CalendarEventDetails(event);
+			rval.setSiteId(siteId);
+			return rval;
+		} catch (final IdUnusedException e) {
 			throw new EntityNotFoundException("Invalid siteId: " + siteId,
 					siteId);
-		} catch (PermissionException e) {
+		} catch (final PermissionException e) {
 			throw new EntityNotFoundException("No access to site: " + siteId,
 					siteId);
 		}
+	}
+
+	/**
+	 * Helper to get the events for a site
+	 *
+	 * @param siteId siteId. If myworkspace, should already have the ~ prepended.
+	 * @param range {@link TimeRange} to filter by. Must be null if not sending one.
+	 * @return
+	 */
+	private List<CalendarEventSummary> getEventsForSite(final String siteId, final TimeRange range) {
+
+		final List<CalendarEventSummary> rval = new ArrayList<CalendarEventSummary>();
+
+		try {
+			final Calendar cal = this.calendarService.getCalendar(String.format(
+					"/calendar/calendar/%s/main", siteId));
+
+			for (final Object o : cal.getEvents(range, null)) {
+				final CalendarEvent event = (CalendarEvent) o;
+
+				final CalendarEventSummary summary = new CalendarEventSummary(event);
+				summary.setEventImage(eventImageMap.get(event.getType()));
+				summary.setSiteId(siteId);
+				rval.add(summary);
+			}
+		} catch (final IdUnusedException e) {
+			// may not have a calendar, skip it
+		} catch (final PermissionException e) {
+			// may not have access, skip it
+		}
+
+		return rval;
+	}
+
+	/**
+	 * Build a {@link TimeRange} from the supplied request parameters. If the parameters are supplied but invalid, an
+	 * {@link IllegalArgumentException} will be thrown.
+	 *
+	 * @param params the request params
+	 * @return {@link TimeRange} if valid or null if not
+	 */
+	private TimeRange buildTimeRangeFromRequest(final Map<String, Object> params) {
+
+		// OPTIONAL params
+		String firstDate = null;
+		String lastDate = null;
+		if (params.containsKey("firstDate")) {
+			firstDate = (String) params.get("firstDate");
+		}
+		if (params.containsKey("lastDate")) {
+			lastDate = (String) params.get("lastDate");
+		}
+
+		// check date params are correct (length is ok)
+		if (StringUtils.isNotBlank(firstDate) && StringUtils.length(firstDate) != 10) {
+			throw new IllegalArgumentException(
+					"firstDate must be in the format yyyy-MM-dd");
+		}
+		if (StringUtils.isNotBlank(lastDate) && StringUtils.length(lastDate) != 10) {
+			throw new IllegalArgumentException(
+					"lastDate must be in the format yyyy-MM-dd");
+		}
+
+		// if we have dates, create a range for filtering
+		// these need to be converted to Time and then a TimeRange created. This is what the CalendarService uses to filter :(
+		// note that our firstDate is always the beginning of the day and the lastDate is always the end
+		// this is to ensure we get full days
+		TimeRange range = null;
+		if (StringUtils.isNotBlank(firstDate) && StringUtils.isNotBlank(lastDate)) {
+			final Time start = this.timeService.newTimeLocal(
+					Integer.valueOf(StringUtils.substring(firstDate, 0, 4)),
+					Integer.valueOf(StringUtils.substring(firstDate, 5, 7)),
+					Integer.valueOf(StringUtils.substring(firstDate, 8, 10)),
+					0, 0, 0, 0);
+
+			final Time end = this.timeService.newTimeLocal(
+					Integer.valueOf(StringUtils.substring(lastDate, 0, 4)),
+					Integer.valueOf(StringUtils.substring(lastDate, 5, 7)),
+					Integer.valueOf(StringUtils.substring(lastDate, 8, 10)),
+					23, 59, 59, 999);
+
+			range = this.timeService.newTimeRange(start, end, true, true);
+		}
+		return range;
+	}
+
+	/**
+	 * get events for all the internal merged calendars for a given site
+	 * @param siteId
+	 * @param range
+	 * @return
+	 */
+	private List<CalendarEventSummary> getMergedCalendarEventsForSite(final String siteId, final TimeRange range) {
+		List<CalendarEventSummary> mergeCal = new ArrayList<CalendarEventSummary>();
+		CalendarEventVector calendarEventVector = calendarService.getEvents(calendarService.getCalendarReferences(siteId), range);
+		for (Object o : calendarEventVector) {
+			CalendarEvent event = (CalendarEvent) o;
+
+			CalendarEventSummary eventSummary = new CalendarEventSummary(event);
+			eventSummary.setEventImage(eventImageMap.get(event.getType()));
+			//as event can be from different site , find sitId for the event
+			Reference reference = entityManager.newReference(event.getCalendarReference());
+			eventSummary.setSiteId(reference.getContext());
+			mergeCal.add(eventSummary);
+		}
+		return mergeCal;
 	}
 
 }

--- a/calendar-tool/tool/src/java/org/sakaiproject/calendar/entityproviders/CalendarEventSummary.java
+++ b/calendar-tool/tool/src/java/org/sakaiproject/calendar/entityproviders/CalendarEventSummary.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import org.sakaiproject.calendar.api.CalendarEvent;
 import org.sakaiproject.calendar.api.RecurrenceRule;
 import org.sakaiproject.time.api.Time;
+import org.sakaiproject.util.CalendarUtil;
 
 @Data
 public class CalendarEventSummary {
@@ -16,7 +17,20 @@ public class CalendarEventSummary {
 	private String creator;
 	private Time firstTime;
 	private long duration;
+	private String description;
 	private RecurrenceRule recurrenceRule;
+
+	/**
+	 * This field will only be set if the event is an assignment and can be used to reconstrut the deepLink
+	 */
+	private String assignmentId;
+
+	/**
+	 * Set externally after object creation, signals the site the event came from (not part of CalendarEvent)
+	 */
+	private String siteId;
+	//icon used for specific eventType
+	private String eventImage;
 
 	public CalendarEventSummary() {
 	}
@@ -31,6 +45,8 @@ public class CalendarEventSummary {
 		firstTime = event.getRange().firstTime();
 		duration = event.getRange().duration();
 		recurrenceRule = event.getRecurrenceRule();
+		description = event.getDescriptionFormatted();
+		assignmentId = event.getField(CalendarUtil.NEW_ASSIGNMENT_DUEDATE_CALENDAR_ASSIGNMENT_ID);
 	}
 
 }

--- a/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -53,6 +53,7 @@ import org.sakaiproject.alias.cover.AliasService;
 import org.sakaiproject.authz.api.PermissionsHelper;
 import org.sakaiproject.authz.cover.SecurityService;
 import org.sakaiproject.calendar.api.*;
+import org.sakaiproject.calendar.api.Calendar;
 import org.sakaiproject.calendar.cover.CalendarImporterService;
 import org.sakaiproject.calendar.cover.CalendarService;
 import org.sakaiproject.entitybroker.exception.EntityNotFoundException;
@@ -212,7 +213,9 @@ extends VelocityPortletStateAction
 	private final static String ASSN_ENTITY_PREFIX = EntityReference.SEPARATOR+ASSN_ENTITY_ID+EntityReference.SEPARATOR+ASSN_ENTITY_ACTION+EntityReference.SEPARATOR;
    
 	private NumberFormat monthFormat = null;
+	//Map for event icons
 	
+	private Map<String, String> eventIconMap;
 	/**
 	 * Converts a string that is used to store additional attribute fields to an array of strings.
 	 */
@@ -2484,6 +2487,7 @@ extends VelocityPortletStateAction
 		context.put("state", state.getKey());
 		context.put("tlang",rb);
 		context.put("config",configProps);
+		context.put("eventIconMap", eventIconMap);
 		context.put("dateFormat", getDateFormatString());
 		context.put("timeFormat", getTimeFormatString());
       
@@ -8068,6 +8072,8 @@ extends VelocityPortletStateAction
 				inConfig = this.getClass().getResourceAsStream("calendar.config");
 				configProps.load(inConfig);
 			}
+			//get map with key as event and value as image, if empty then create one.
+			eventIconMap = new CalendarUtil().getEventImageMap(configProps);
 		}
 		catch ( IOException e )
 		{

--- a/calendar-tool/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/calendar-tool/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -3,12 +3,12 @@
 
 <beans>
 	<bean parent="org.sakaiproject.entitybroker.entityprovider.AbstractEntityProvider"
-		class="org.sakaiproject.calendar.entityproviders.CalendarEventEntityProvider">
+		class="org.sakaiproject.calendar.entityproviders.CalendarEventEntityProvider" init-method="init">
 		<property name="calendarService"
 			ref="org.sakaiproject.calendar.api.CalendarService" />
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
-		<property name="developerHelperService"
-			ref="org.sakaiproject.entitybroker.DeveloperHelperService" />
+		<property name="timeService" ref="org.sakaiproject.time.api.TimeService" />
+		<property name="entityManager"><ref bean="org.sakaiproject.entity.api.EntityManager"/></property>
 	</bean>
 	
 </beans>

--- a/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar.vm
+++ b/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar.vm
@@ -54,49 +54,8 @@ calendar Portlet
 *#
 
 #macro (iconImage $eventType)
-#if ($eventType=="Academic Calendar")
-<img src = "#imageLink("$config.getProperty('legend.icon1')")" alt="$tlang.getString('legend.key1')" border="0">
-#elseif ($eventType =="Activity")
-<img src = "#imageLink("$config.getProperty('legend.icon2')")" alt="$tlang.getString('legend.key2')" border="0">
-#elseif ($eventType =="Cancellation")
-<img src = "#imageLink("$config.getProperty('legend.icon3')")" alt="$tlang.getString('legend.key3')" border="0">
-#elseif ($eventType =="Class section - Discussion")
-<img src = "#imageLink("$config.getProperty('legend.icon4')")" alt ="$tlang.getString('legend.key4')" border="0">
-#elseif ($eventType =="Class section - Lab")
-<img src = "#imageLink("$config.getProperty('legend.icon5')")" alt="$tlang.getString('legend.key5')" border="0">
-#elseif ($eventType =="Class section - Lecture")
-<img src = "#imageLink("$config.getProperty('legend.icon6')")" alt="$tlang.getString('legend.key6')" border="0">
-#elseif ($eventType =="Class section - Small Group")
-<img src = "#imageLink("$config.getProperty('legend.icon7')")" alt="$tlang.getString('legend.key7')" border="0">
-#elseif ($eventType =="Class session")
-<img src = "#imageLink("$config.getProperty('legend.icon8')")" alt="$tlang.getString('legend.key8')" border="0">
-#elseif ($eventType =="Computer Session")
-<img src = "#imageLink("$config.getProperty('legend.icon9')")" alt="$tlang.getString('legend.key9')" border="0">
-#elseif ($eventType =="Deadline")
-<img src = "#imageLink("$config.getProperty('legend.icon10')")" alt="$tlang.getString('legend.key10')" border="0">
-#elseif ($eventType =="Exam")
-<img src = "#imageLink("$config.getProperty('legend.icon11')")" alt="$tlang.getString('legend.key11')" border="0">
-#elseif ($eventType =="Meeting")
-<img src = "#imageLink("$config.getProperty('legend.icon12')")" alt="$tlang.getString('legend.key12')" border="0">
-#elseif ($eventType =="Multidisciplinary Conference")
-<img src = "#imageLink("$config.getProperty('legend.icon13')")" alt="$tlang.getString('legend.key13')" border="0">
-#elseif ($eventType =="Quiz")
-<img src = "#imageLink("$config.getProperty('legend.icon14')")" alt="$tlang.getString('legend.key14')" border="0">
-#elseif ($eventType =="Special event")
-<img src = "#imageLink("$config.getProperty('legend.icon15')")" alt="$tlang.getString('legend.key15')" border="0">
-#elseif ($eventType =="Web Assignment")
-<img src = "#imageLink("$config.getProperty('legend.icon16')")" alt="$tlang.getString('legend.key16')" border="0">
-#elseif ($eventType =="Tutorial")
-<img src = "#imageLink("$config.getProperty('legend.icon17')")" alt="$tlang.getString('legend.key17')" border="0">
-#elseif ($eventType =="Workshop")
-<img src = "#imageLink("$config.getProperty('legend.icon18')")" alt="$tlang.getString('legend.key18')" border="0">
-#elseif ($eventType =="Submission Date")
-<img src = "#imageLink("$config.getProperty('legend.icon19')")" alt="$tlang.getString('legend.key19')" border="0">
-#elseif ($eventType =="Formative Assessment")
-<img src = "#imageLink("$config.getProperty('legend.icon20')")" alt="$tlang.getString('legend.key20')" border="0">
+<img src = "#imageLink($eventIconMap.get($eventType))" alt="$eventType" border="0">
 #end
-#end
-
 
 #if ($message=='new')
         #parse("/vm/calendar/chef_calendar_new.vm")

--- a/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
+++ b/calendar-util/util/src/java/org/sakaiproject/util/CalendarUtil.java
@@ -26,6 +26,12 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.ResourceBundle;
+import java.util.HashMap;
+import java.util.Enumeration;
+
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -66,6 +72,7 @@ public class CalendarUtil
 	Date dateOctober = null;
 	Date dateNovember = null;
 	Date dateDecember = null;
+	private Map<String, String> eventIconMap = new HashMap<String, String>();
 
 	public final static String NEW_ASSIGNMENT_DUEDATE_CALENDAR_ASSIGNMENT_ID = "new_assignment_duedate_calendar_assignment_id";
 	
@@ -579,5 +586,27 @@ public class CalendarUtil
 		DateTimeFormatter df = new DateTimeFormatterBuilder().appendHalfdayOfDayText().toFormatter().withLocale(locale);
 		return df.print(dt);
 	}
-	
+
+	/**
+	 * get Map for eventType and image
+	 * @param configProps
+	 * @return
+	 */
+	public Map<String, String> getEventImageMap(Properties configProps){
+		if(eventIconMap.size() == 0){
+			//load keys for locale root
+			Map<String, String> eventKeyMap = new HashMap<String, String>();
+			ResourceBundle bundle = ResourceBundle.getBundle("calendar", Locale.ROOT);
+			for(Enumeration e = bundle.getKeys(); e.hasMoreElements();){
+				String bundleKey = (String)e.nextElement();
+				eventKeyMap.put(bundleKey, bundle.getString(bundleKey));
+			}
+			for(int i=1; i<=20; i++){
+				String key = eventKeyMap.get("legend.key" + i);
+				String value = configProps.getProperty("legend.icon" + i);
+				eventIconMap.put(key, value);
+			}
+		}
+		return eventIconMap;
+	}
 }	 // CalendarUtil


### PR DESCRIPTION
Exposed method 'getCalendarReferences' in CalendarService to get
references from all calendars for a site.
Added attributes 'description' and 'eventImage' in the EventSummary class
which will be used in the json returned by CalendarEventEntityProvider.
Created map for event type and image in the CalendarUtil class which can be
accessed using method 'getEventImageMap'.
CalendarEventEntityProvider's 'getCalendarEventsForSite' will now return
events from all the merged calendars for a site.
